### PR TITLE
Osumano securitycontrols init

### DIFF
--- a/projects/working-groups/overview.md
+++ b/projects/working-groups/overview.md
@@ -1,0 +1,15 @@
+# Overview
+
+The Financial Services User Group has decided to focus on security controls for Kubernetes and ecosystem. 
+
+
+# List of working groups
+
+
+| Area of Focus | Lead | Members |
+|---------------|------|---------|
+| Kubernetes    | open | needed  | 
+| ......        | .... | ......  |
+
+
+


### PR DESCRIPTION
I added a new directory ( working-groups ) under projects. 

I also added an overview.md file in that directory with initial content. 

The idea is to get group members to add the areas of focus, volunteers to lead and group membership. 

